### PR TITLE
Ensure rvi-probe scripts are executable in IPK build

### DIFF
--- a/.github/workflows/build-ipk.yml
+++ b/.github/workflows/build-ipk.yml
@@ -56,6 +56,14 @@ jobs:
         
         # Copy package files to payload (excluding CONTROL)
         cp -r package/rvi-probe/files/* dist/payload/
+
+        # Ensure scripts and init files are executable
+        chmod 0755 dist/payload/etc/init.d/rvi-probe
+        chmod 0755 dist/payload/usr/bin/rvi-*
+        chmod 0755 dist/payload/usr/lib/rvi-probe/agent.sh
+        chmod 0755 dist/payload/usr/lib/rvi-probe/cell.sh
+        chmod 0755 dist/payload/www/cgi-bin/supportlink
+        chmod 0755 dist/payload/www/cgi-bin/json
         
         # Verify control file exists
         test -s dist/pkg/CONTROL/control


### PR DESCRIPTION
## Summary
- Add explicit chmod commands in build-ipk workflow so copied scripts and init files are executable

## Testing
- `yamllint .github/workflows/build-ipk.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a5c670748324b5353e3b0ba0723b