### PR TITLE
ci: skip redundant AWS CLI install in build-ipk workflow

### DIFF
--- a/.github/workflows/build-ipk.yml
+++ b/.github/workflows/build-ipk.yml
@@ -1,3 +1,14 @@
+- name: Install AWS CLI v2
+  run: |
+    set -euxo pipefail
+    if command -v aws >/dev/null 2>&1; then
+      echo "AWS CLI already installed"
+    else
+      curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip
+      unzip -q awscliv2.zip
+      sudo ./aws/install --update
+    fi
+
 - name: Create IPK package manually
   run: |
     set -euxo pipefail


### PR DESCRIPTION
## Summary
- avoid reinstalling AWS CLI if it's already present

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1d6900d88832483852006490ac938