### PR TITLE
Insert package version into postinst before building IPK

### DIFF
--- a/scripts/build-openwrt.sh
+++ b/scripts/build-openwrt.sh
@@ -3,7 +3,20 @@ set -euo pipefail
 SDK_DIR=${1:? "usage: $0 <sdk-dir> <arch>"}
 ARCH=${2:-x86_64}
 PKG_SRC_DIR=$(cd "$(dirname "$0")/.."; pwd)/package/rvi-probe
+
 cd "$SDK_DIR"; ./scripts/feeds update -a && ./scripts/feeds install -a
-mkdir -p package/utils/rvi-probe; rsync -a --delete "$PKG_SRC_DIR"/ package/utils/rvi-probe/
-make defconfig; make package/rvi-probe/compile V=s
+
+mkdir -p package/utils/rvi-probe
+rsync -a --delete "$PKG_SRC_DIR"/ package/utils/rvi-probe/
+
+# Insert the package version into the post-install script so that the
+# generated IPK contains a URL pointing to the correct installer payload.
+PKG_VERSION=$(grep -m1 '^PKG_VERSION:=' "$PKG_SRC_DIR/Makefile" | cut -d= -f2 | tr -d ' \t')
+PKG_RELEASE=$(grep -m1 '^PKG_RELEASE:=' "$PKG_SRC_DIR/Makefile" | cut -d= -f2 | tr -d ' \t')
+POSTINST=package/utils/rvi-probe/files/CONTROL/postinst
+sed -e "s/__VER__/${PKG_VERSION}-${PKG_RELEASE}/" "$POSTINST" > "${POSTINST}.tmp"
+mv "${POSTINST}.tmp" "$POSTINST"
+
+make defconfig
+make package/rvi-probe/compile V=s
 echo "Built packages in: $(pwd)/bin/packages"


### PR DESCRIPTION
## Summary
- Inject PKG_VERSION and PKG_RELEASE into `files/CONTROL/postinst` during `build-openwrt.sh`
- Ensure generated IPK contains versioned installer URL

## Testing
- `bash scripts/build-openwrt.sh "$tmpdir" test-arch` *(with stubbed SDK and make)*
- `PATH="$testbin" /bin/sh "$tmpdir/package/utils/rvi-probe/files/CONTROL/postinst"` *(stubbed environment, verifies curl fallback)*


------
https://chatgpt.com/codex/tasks/task_e_68b4ef5da4548324ab69da046b9c2949