### PR TITLE
Use awk for version parsing in R2 publish script

### DIFF
--- a/scripts/publish-r2.sh
+++ b/scripts/publish-r2.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 OUT=${1:-bin/packages}
 
 PKG_MK=$(cd "$(dirname "$0")/.."; pwd)/package/rvi-probe/Makefile
-PKG_VERSION=$(grep '^PKG_VERSION:=' "$PKG_MK" | cut -d':=' -f2 | tr -d ' \t')
-PKG_RELEASE=$(grep '^PKG_RELEASE:=' "$PKG_MK" | cut -d':=' -f2 | tr -d ' \t')
+PKG_VERSION=$(grep '^PKG_VERSION:=' "$PKG_MK" | awk -F ':=' '{print $2}' | tr -d ' \t')
+PKG_RELEASE=$(grep '^PKG_RELEASE:=' "$PKG_MK" | awk -F ':=' '{print $2}' | tr -d ' \t')
 PKG_VER="${PKG_VERSION}-${PKG_RELEASE}"
 
 # Generate versioned installer script and copy IPK to the output root


### PR DESCRIPTION
## Summary
- parse PKG_VERSION and PKG_RELEASE with awk instead of invalid multi-character cut delimiter

## Testing
- `bash scripts/publish-r2.sh` *(fails: Install awscli v2)*
- `apt-get update` *(fails: The repository is not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68b5ca7e191083248e8d7e1152cc196f