### PR TITLE
Ensure cloudflared installed during OpenWrt setup

### DIFF
--- a/installer/probe.sh
+++ b/installer/probe.sh
@@ -25,10 +25,15 @@ install_openwrt(){
     TMP=$(mktemp); URL="${RV_FEED_URL}/${ARCH}/rvi-probe_${PKG_VERSION}-${PKG_RELEASE}_${ARCH}.ipk"
     curl -fsSL "$URL" -o "$TMP"; $SUDO opkg install "$TMP" && rm -f "$TMP"
   }
+  $SUDO opkg install cloudflared || {
+    log "Falling back to direct cloudflared ipk download"; TMPDIR=$(mktemp -d)
+    (cd "$TMPDIR" && opkg download cloudflared && $SUDO opkg install ./*.ipk) && rm -rf "$TMPDIR"
+  }
   $SUDO uci set rviprobe.config.worker_url="$RV_WORKER_URL" || true
   $SUDO uci commit rviprobe || true
   $SUDO /etc/init.d/rvi-probe enable || true
   $SUDO /etc/init.d/rvi-probe start || true
+  $SUDO rvi-cloudflared-check || true
   log "OpenWrt install complete"
 }
 


### PR DESCRIPTION
## Summary
- Install `cloudflared` in OpenWrt installer with a fallback direct download
- Run `rvi-cloudflared-check` after service startup to verify binary and token

## Testing
- `bash -n installer/probe.sh`
- `bash package/rvi-probe/files/usr/bin/rvi-cloudflared-check > /tmp/rvi.log 2>&1 && cat /tmp/rvi.log` *(fails: cloudflared binary missing)*


------
https://chatgpt.com/codex/tasks/task_e_68b5d1d0a8b48324a24d94605f9e628b