### PR TITLE
Verify OpenWrt tunnel and HTTP services on install

### DIFF
--- a/installer/probe.sh
+++ b/installer/probe.sh
@@ -14,12 +14,34 @@ CF_RELEASE="${CF_RELEASE:-1}"
 is_openwrt(){ [ -f /etc/openwrt_release ] || command -v opkg >/dev/null 2>&1; }
 lsb(){ [ -f /etc/os-release ] && . /etc/os-release; ID="${ID:-}"; }
 
+verify_openwrt_services(){
+  metrics=$(awk '/^ *metrics:/{print $2}' /etc/cloudflared/config.yml 2>/dev/null | tail -n1)
+  metrics=${metrics:-127.0.0.1:2000}
+  uhttpd=$(uci get uhttpd.rvi.listen_http 2>/dev/null || true)
+  uhttpd=${uhttpd:-127.0.0.1:8081}
+  sleep 5
+  curl -fsS --max-time 5 "http://$metrics/ready" >/dev/null || {
+    log "cloudflared not ready at $metrics"; exit 1; }
+  resp=$(curl -fsS --max-time 5 "http://$uhttpd/json" 2>/dev/null) || {
+    log "probe HTTP check failed at $uhttpd"; exit 1; }
+  if command -v jq >/dev/null 2>&1; then
+    echo "$resp" | jq . >/dev/null || { log "invalid JSON from probe"; exit 1; }
+  else
+    echo "$resp" | grep -q '{' || { log "invalid JSON from probe"; exit 1; }
+  fi
+}
+
 install_openwrt(){
   log "Detected OpenWrt/FriendlyWrt"
   $SUDO opkg update || true
   if ! grep -q "rvi_r2" /etc/opkg/customfeeds.conf 2>/dev/null; then
     ARCH=$(opkg print-architecture | tail -n1 | awk '{print $2}')
     echo "src/gz rvi_r2 ${RV_FEED_URL}/${ARCH}" | $SUDO tee -a /etc/opkg/customfeeds.conf
+  fi
+  if ! grep -q '^src/gz luci ' /etc/opkg/customfeeds.conf 2>/dev/null; then
+    DIST=$(. /etc/openwrt_release; echo $DISTRIB_RELEASE)
+    ARCH=$(opkg print-architecture | tail -n1 | awk '{print $2}')
+    echo "src/gz luci https://downloads.openwrt.org/releases/${DIST}/packages/${ARCH}/luci" | $SUDO tee -a /etc/opkg/customfeeds.conf
   fi
   $SUDO opkg update
   $SUDO opkg install ca-bundle ca-certificates curl jq || true
@@ -36,12 +58,18 @@ install_openwrt(){
     curl -fsSL "$URL" -o "$TMP"
     $SUDO opkg install "$TMP" && rm -f "$TMP"
   }
-  $SUDO rvi-cloudflared-check || true
+  CF_OUT=$($SUDO rvi-cloudflared-check 2>&1) || { rc=$?; log "rvi-cloudflared-check failed: $CF_OUT"; exit $rc; }
+  echo "$CF_OUT"
+  HOSTNAME=$(printf '%s\n' "$CF_OUT" | awk '/hostname:/{print $2}' | tail -n1)
+  $SUDO /etc/init.d/cloudflared enable
+  $SUDO /etc/init.d/cloudflared start
   $SUDO uci set rviprobe.config.worker_url="$RV_WORKER_URL" || true
   $SUDO uci commit rviprobe || true
   $SUDO /etc/init.d/rvi-probe enable || true
   $SUDO /etc/init.d/rvi-probe start || true
-  $SUDO rvi-cloudflared-check || true
+  $SUDO rvi-cloudflared-check >/dev/null || { log "rvi-cloudflared-check failed after start"; exit 1; }
+  verify_openwrt_services
+  [ -n "$HOSTNAME" ] && log "Tunnel available at https://$HOSTNAME"
   log "OpenWrt install complete"
 }
 

--- a/package/rvi-probe/files/usr/bin/rvi-cloudflared-check
+++ b/package/rvi-probe/files/usr/bin/rvi-cloudflared-check
@@ -4,6 +4,7 @@ CF_BIN=/usr/bin/cloudflared
 TOKEN_FILE=/etc/cloudflared/token
 INIT=/etc/init.d/cloudflared
 WORKER_URL="https://status-hunter.traveldata.workers.dev/provision"
+HOST_FILE=/etc/cloudflared/hostname
 
 install_cloudflared() {
   if command -v opkg >/dev/null 2>&1; then
@@ -49,13 +50,18 @@ fetch_token() {
   fi
   TOKEN=$(printf '%s' "$RES" | sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]\+\)".*/\1/p' | head -n1)
   [ -z "$TOKEN" ] && TOKEN=$(echo "$RES" | jq -r '.token // empty' 2>/dev/null || true)
-  if [ -n "$TOKEN" ] && [ "$TOKEN" != "TOKEN_PLACEHOLDER" ] && [ ${#TOKEN} -ge 32 ]; then
+  HOST=$(printf '%s' "$RES" | sed -n 's/.*"hostname"[[:space:]]*:[[:space:]]*"\([^"]\+\)".*/\1/p' | head -n1)
+  [ -z "$HOST" ] && HOST=$(echo "$RES" | jq -r '.hostname // empty' 2>/dev/null || true)
+  if [ -n "$TOKEN" ] && [ "$TOKEN" != "TOKEN_PLACEHOLDER" ] && [ ${#TOKEN} -ge 32 ] && [ -n "$HOST" ]; then
     mkdir -p "$(dirname "$TOKEN_FILE")" 2>/dev/null; umask 077
     printf '%s' "$TOKEN" > "$TOKEN_FILE"
     chmod 0600 "$TOKEN_FILE" 2>/dev/null || true
-    echo "token retrieved"
+    printf '%s' "$HOST" > "$HOST_FILE"
+    chmod 0600 "$HOST_FILE" 2>/dev/null || true
+    echo "token retrieved for $HOST"
+    echo "hostname: $HOST"
   else
-    echo "failed to fetch valid token" >&2
+    echo "failed to fetch valid token or hostname" >&2
     return 1
   fi
 }
@@ -107,6 +113,7 @@ check_token() {
       return 1
     fi
   fi
+  [ -f "$HOST_FILE" ] && echo "hostname: $(cat "$HOST_FILE")"
 }
 
 check_status() {


### PR DESCRIPTION
## Summary
- Add Luci applications feed if missing so cloudflared package is available
- Fail fast on rvi-cloudflared-check errors, start cloudflared service, and print tunnel URL
- Verify cloudflared metrics and probe HTTP endpoint after install
- Capture hostname during cloudflared provisioning

## Testing
- `bash -n installer/probe.sh`
- `bash -n package/rvi-probe/files/usr/bin/rvi-cloudflared-check`
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68b5e84e6b488324a331035657d6ede4