### PR TITLE
Add SupportLink HTML wrapper and deploy script

### DIFF
--- a/scripts/deploy-supportlink-wrapper.sh
+++ b/scripts/deploy-supportlink-wrapper.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+SRC_DIR=$(dirname "$0")
+WRAPPER="$SRC_DIR/supportlink-wrapper"
+TARGET=/www/cgi-bin/supportlink
+BACKUP=/www/cgi-bin/supportlink.api
+
+if [ ! -f "$BACKUP" ] && [ -f "$TARGET" ]; then
+  mv "$TARGET" "$BACKUP"
+fi
+
+cp "$WRAPPER" "$TARGET"
+chmod +x "$TARGET"
+
+/etc/init.d/uhttpd restart >/dev/null 2>&1 || true
+
+# Verification
+printf 'HTML check: '
+curl -fsS http://localhost/cgi-bin/supportlink | head -n 1 || true
+printf '\nJSON check: '
+curl -fsS -H 'Accept: application/json' http://localhost/cgi-bin/supportlink | head -n 1 || true

--- a/scripts/supportlink-wrapper
+++ b/scripts/supportlink-wrapper
@@ -1,0 +1,347 @@
+#!/bin/sh
+
+QS="$QUERY_STRING"
+ACCEPT="$HTTP_ACCEPT"
+API=0
+
+case "$QS" in
+  *action=*|*provider=*) API=1 ;;
+esac
+case "$ACCEPT" in
+  *application/json*|*text/json*) API=1 ;;
+esac
+
+if [ "$API" -eq 1 ]; then
+  if [ -x /www/cgi-bin/supportlink.api ]; then
+    exec /www/cgi-bin/supportlink.api "$@"
+  else
+    printf 'Status: 500\r\n'
+    printf 'Content-Type: text/plain; charset=UTF-8\r\n\r\n'
+    printf 'SupportLink API handler missing\n'
+  fi
+  exit 0
+fi
+
+printf 'Content-Type: text/html; charset=UTF-8\r\n\r\n'
+cat <<'HTML'
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SupportLink • Device Status</title>
+<style>
+  :root {
+    --bg:#0f172a; --panel:#111827; --muted:#9ca3af; --ok:#10b981; --warn:#f59e0b; --bad:#ef4444; --accent:#60a5fa;
+    --btn:#1f2937; --btnHover:#374151;
+  }
+  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:#e5e7eb;font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+  .wrap{max-width:960px;margin:40px auto;padding:0 16px}
+  .card{background:var(--panel);border:1px solid #1f2937;border-radius:16px;padding:20px;box-shadow:0 10px 30px rgba(0,0,0,.25)}
+  h1{font-size:28px;margin:0 0 8px}
+  .sub{color:var(--muted);margin:0 0 14px}
+  .grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .pill{display:inline-flex;align-items:center;gap:8px;padding:6px 10px;border-radius:999px;font-weight:600}
+  .ok{background:rgba(16,185,129,.14);color:#34d399;border:1px solid rgba(16,185,129,.35)}
+  .warn{background:rgba(245,158,11,.14);color:#fbbf24;border:1px solid rgba(245,158,11,.35)}
+  .bad{background:rgba(239,68,68,.14);color:#f87171;border:1px solid rgba(239,68,68,.35)}
+  .muted{color:var(--muted)}
+  .stat{padding:14px;border:1px dashed #374151;border-radius:12px}
+  .k{display:block;color:var(--muted);font-size:12px}
+  .v{font:600 18px/1.2 system-ui}
+  .actions{display:flex;flex-wrap:wrap;gap:12px;margin-top:8px}
+  button{appearance:none;border:1px solid #374151;background:var(--btn);color:#e5e7eb;border-radius:12px;padding:12px 16px;cursor:pointer;font-weight:600}
+  button:hover{background:var(--btnHover)}
+  .accent{border-color:#1e40af}
+  .danger{border-color:#7f1d1d}
+  .wide{width:100%}
+  .mono{font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono","Courier New", monospace}
+  .small{font-size:12px}
+  .hr{height:1px;background:#1f2937;margin:16px 0}
+  .log{background:#0b1022;border:1px solid #1f2937;border-radius:12px;padding:12px;white-space:pre-wrap;max-height:300px;overflow:auto}
+  .row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+
+  /* Modal + chips */
+  .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:16px;z-index:1000;background:rgba(0,0,0,.45)}
+  .modal.open{display:flex}
+  .modal-content{background:var(--panel);border:1px solid #1f2937;border-radius:16px;max-width:900px;width:100%;padding:20px;box-shadow:0 20px 60px rgba(0,0,0,.4)}
+  .modal-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px}
+  .close{cursor:pointer;font-weight:700;border:1px solid #374151;border-radius:8px;padding:4px 10px}
+  .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
+  .chip{font-size:13px;padding:8px 10px;border-radius:999px;border:2px solid #374151;background:#0e162d;color:#d1d5db;cursor:pointer}
+  .chip[disabled]{opacity:.65;cursor:not-allowed}
+  .result-card{border:1px solid #1f2937;border-radius:12px;padding:10px;background:#0b1022}
+  .kgrid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px}
+  .muted-link{color:#93c5fd;text-decoration:none}
+  .muted-link:hover{text-decoration:underline}
+
+  /* Chip status outlines */
+  .chip.ok{ border-color:#10b981; color:#10b981; }
+  .chip.warn{ border-color:#f59e0b; color:#f59e0b; }
+  .chip.bad{ border-color:#ef4444; color:#ef4444; }
+  .chip.unknown{ border-color:#6b7280; color:#9ca3af; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="card">
+    <h1>SupportLink</h1>
+    <p class="sub">Fast help from RV Internet Help. Keep this page open if you’re on the phone with support.</p>
+
+    <div class="grid" id="stats">
+      <div class="stat"><span class="k">Hostname</span><span class="v mono" id="host">—</span></div>
+      <div class="stat"><span class="k">Device ID</span><span class="v mono" id="did">—</span></div>
+      <div class="stat"><span class="k">Share Code (tell support)</span><span class="v mono" id="code">—</span><span class="small muted">Changes every 5 minutes</span></div>
+      <div class="stat"><span class="k">Internet</span><span class="v" id="inet">—</span></div>
+    </div>
+
+    <div class="row" style="margin-top:10px">
+      <span id="statusPill" class="pill warn">Checking…</span>
+      <span class="muted small">Last updated <span id="ago">—</span></span>
+    </div>
+
+    <div class="hr"></div>
+
+    <div class="actions">
+      <button class="accent" id="btnSpeed">Run Speed Test</button>
+      <button id="btnInetDetails">Internet Details</button>
+      <button class="danger" id="btnReboot">Restart My Router</button>
+    </div>
+
+    <div id="results" class="log" style="display:none;margin-top:12px"></div>
+  </div>
+</div>
+
+<!-- Internet Details Modal -->
+<div class="modal" id="inetModal" aria-hidden="true">
+  <div class="modal-content">
+    <div class="modal-header">
+      <h3 style="margin:0">Internet Details</h3>
+      <button class="close" id="inetClose">Close</button>
+    </div>
+
+    <div id="inetBody" class="result-card">
+      <div class="small muted">Loading network info…</div>
+    </div>
+
+    <h4 style="margin:14px 0 6px">Outage Signals</h4>
+    <div class="chips" id="providerChips">
+      <!-- Carriers/ISPs -->
+      <button class="chip" data-provider="att">AT&amp;T</button>
+      <button class="chip" data-provider="verizon">Verizon</button>
+      <button class="chip" data-provider="tmobile">T-Mobile</button>
+      <button class="chip" data-provider="xfinity">Xfinity</button>
+      <button class="chip" data-provider="spectrum">Spectrum</button>
+      <button class="chip" data-provider="cox">Cox</button>
+      <button class="chip" data-provider="starlink">Starlink</button>
+      <!-- Streaming (top 4 + YouTube) -->
+      <button class="chip" data-provider="youtube">YouTube</button>
+      <button class="chip" data-provider="netflix">Netflix</button>
+      <button class="chip" data-provider="disneyplus">Disney+</button>
+      <button class="chip" data-provider="hulu">Hulu</button>
+      <!-- Work apps -->
+      <button class="chip" data-provider="zoom">Zoom</button>
+      <button class="chip" data-provider="slack">Slack</button>
+      <button class="chip" data-provider="m365">Microsoft&nbsp;365</button>
+      <button class="chip" data-provider="teams">Teams</button>
+      <button class="chip" data-provider="github">GitHub</button>
+      <button class="chip" data-provider="cloudflare">Cloudflare</button>
+      <button class="chip" data-provider="openai">OpenAI</button>
+    </div>
+
+    <div id="outageResults" style="display:grid;gap:8px;margin-top:10px"></div>
+
+    <details style="margin-top:12px">
+      <summary>Privacy</summary>
+      <small class="muted">We fetch only public IP/ASN and public status pages. No browsing content is inspected. DNS-based app detection remains off unless you opt in.</small>
+    </details>
+  </div>
+</div>
+
+<script>
+const $ = sel => document.querySelector(sel);
+const pill = $('#statusPill'),
+      host = $('#host'),
+      did  = $('#did'),
+      inet = $('#inet'),
+      code = $('#code'),
+      ago  = $('#ago'),
+      results = $('#results'),
+      btnSpeed = $('#btnSpeed'),
+      btnReboot = $('#btnReboot'),
+      btnInetDetails = $('#btnInetDetails'),
+      inetModal = $('#inetModal'),
+      inetClose = $('#inetClose'),
+      inetBody = $('#inetBody'),
+      outageResults = $('#outageResults');
+
+function setPill(state){
+  pill.classList.remove('ok','warn','bad');
+  if(state==='active'){ pill.classList.add('ok'); pill.textContent='Online'; }
+  else if(state==='starting'){ pill.classList.add('warn'); pill.textContent='Starting…'; }
+  else { pill.classList.add('bad'); pill.textContent='Offline'; }
+}
+
+let lastFetch=0, currentHost='';
+
+// ---- Share-code helpers (5-minute bucket)
+function timeBucket(){ return Math.floor(Date.now()/300000); }
+async function sha1Hex(str){
+  if (window.crypto?.subtle) {
+    const data = new TextEncoder().encode(str);
+    const buf = await crypto.subtle.digest('SHA-1', data);
+    return [...new Uint8Array(buf)].map(b=>b.toString(16).padStart(2,'0')).join('');
+  }
+  // Fallback CRC32
+  const T=new Uint32Array(256); for(let i=0;i<256;i++){let x=i;for(let k=0;k<8;k++) x=(x&1)?(0xEDB88320^(x>>>1)):(x>>>1);T[i]=x;}
+  let c=0^(-1); for(let i=0;i<str.length;i++){ c=T[(c^str.charCodeAt(i))&0xFF]^(c>>>8); } c=c^(-1);
+  return (c>>>0).toString(16).padStart(8,'0');
+}
+async function computeShareCode(hostname){
+  const seed = `${hostname}:${timeBucket()}:supportlink`;
+  const hex = await sha1Hex(seed);
+  const n = parseInt(hex.slice(0,8),16);
+  return String(n % 1_000_000).padStart(6,'0');
+}
+let lastCodeHost='', lastCodeVal='';
+async function ensureCode(valFromApi){
+  try{
+    if (valFromApi && /^\d{6}$/.test(valFromApi)) { lastCodeVal=valFromApi; code.textContent=valFromApi; return; }
+    if (!currentHost) { code.textContent = '—'; return; }
+    const fresh = await computeShareCode(currentHost);
+    if (fresh !== lastCodeVal){ lastCodeVal = fresh; lastCodeHost = currentHost; }
+    code.textContent = lastCodeVal;
+  }catch{ code.textContent='—'; }
+}
+
+async function getStatus(){
+  try{
+    const r = await fetch('/cgi-bin/supportlink', {cache:'no-store'});
+    const j = await r.json();
+    currentHost = (j && j.tunnel && j.tunnel.hostname) || '';
+    host.textContent = currentHost || '—';
+    did.textContent  = (j && j.tunnel && j.tunnel.id) || '—';
+    inet.textContent = (j && j.internet || '—').toUpperCase();
+    setPill((j && j.tunnel && j.tunnel.state) || 'down');
+    await ensureCode(j && j.tunnel && j.tunnel.code);
+    lastFetch = Date.now();
+  }catch{ setPill('down'); }
+}
+setInterval(()=>{ if(!lastFetch) return; const s=((Date.now()-lastFetch)/1000)|0; ago.textContent = (s<60?`${s}s`:`${(s/60)|0}m`); },1000);
+async function refresh(){ await getStatus(); await ensureCode(null); setTimeout(refresh, 10000); }
+refresh();
+
+/* -------- Internet Details Modal + Outage Checks ---------- */
+function openModal(){ inetModal.classList.add('open'); inetModal.setAttribute('aria-hidden','false'); }
+function closeModal(){ inetModal.classList.remove('open'); inetModal.setAttribute('aria-hidden','true'); }
+inetClose.onclick = closeModal;
+inetModal.addEventListener('click', (e)=>{ if(e.target===inetModal) closeModal(); });
+
+btnInetDetails.onclick = async ()=>{
+  openModal();
+  inetBody.innerHTML = '<div class="small muted">Loading network info…</div>';
+  outageResults.innerHTML = '';
+  try{
+    const r = await fetch('/cgi-bin/internet_details', {cache:'no-store'});
+    const txt = await r.text();
+    let j; try{ j = JSON.parse(txt); }catch{ throw new Error('Bad JSON from CGI: '+txt.slice(0,120)); }
+    if (j.status === 'error') throw new Error(j.message || 'lookup failed');
+    inetBody.innerHTML = `
+      <div class="kgrid">
+        <div><span class="k">Public IP</span><div class="v mono">${j.ip ?? '—'}</div></div>
+        <div><span class="k">Carrier/ISP</span><div class="v">${j.isp || j.org || '—'}</div></div>
+        <div><span class="k">Type</span><div class="v">${j.type || 'unknown'}</div></div>
+        <div><span class="k">ASN</span><div class="v">${j.asn || '—'}</div></div>
+        <div><span class="k">City/Region</span><div class="v">${(j.city||'—')}, ${(j.region||'—')}</div></div>
+        <div><span class="k">Country</span><div class="v">${j.country || '—'}</div></div>
+        <div><span class="k">Source</span><div class="v">${j.source || 'multiple'}</div></div>
+        <div><span class="k">Updated</span><div class="v small">${j.timestamp ? new Date(j.timestamp*1000).toLocaleString() : '—'}</div></div>
+      </div>`;
+  }catch(e){
+    inetBody.innerHTML = '<div class="small" style="color:#f87171">Unable to load Internet details.<br><span class="muted">'+((e&&e.message)||e)+'</span></div>';
+  }
+};
+
+function labelFor(key){
+  const labels = {att:"AT&T",verizon:"Verizon",tmobile:"T-Mobile",xfinity:"Xfinity",spectrum:"Spectrum",cox:"Cox",starlink:"Starlink",youtube:"YouTube",netflix:"Netflix",disneyplus:"Disney+",hulu:"Hulu",zoom:"Zoom",slack:"Slack",m365:"Microsoft 365",teams:"Teams",github:"GitHub",cloudflare:"Cloudflare",openai:"OpenAI"};
+  return labels[key] || key;
+}
+function statusDot(s){ return s==="normal"?"🟢":s==="elevated"?"🟡":s==="major"?"🔴":"⚪"; }
+function applyChipStatus(chip, status){
+  chip.classList.remove('ok','warn','bad','unknown');
+  if(status==="normal") chip.classList.add('ok');
+  else if(status==="elevated") chip.classList.add('warn');
+  else if(status==="major") chip.classList.add('bad');
+  else chip.classList.add('unknown');
+}
+async function checkProvider(chip, auto=false){
+  const provider = chip.dataset.provider;
+  try{
+    const r = await fetch('/cgi-bin/outage_check?provider='+encodeURIComponent(provider), {cache:'no-store'});
+    const j = await r.json();
+    applyChipStatus(chip, j.status);
+    if(!auto){
+      const card = document.createElement('div');
+      card.className = 'result-card';
+      card.innerHTML = `
+        <div style="display:flex;justify-content:space-between;gap:8px;align-items:center;">
+          <div><strong>${j.display_name || labelFor(provider)}</strong> ${statusDot(j.status)}</div>
+          <div class="small muted">${j.timestamp ? new Date(j.timestamp*1000).toLocaleTimeString() : ''}</div>
+        </div>
+        <div class="small" style="margin-top:4px">${j.summary || 'Status unknown.'}</div>
+        ${j.link ? '<div style="margin-top:6px"><a class="muted-link" href="'+j.link+'" target="_blank" rel="noopener">Check live reports</a></div>' : '' }
+      `;
+      outageResults.prepend(card);
+    }
+  }catch{ applyChipStatus(chip, "unknown"); }
+}
+
+// Bind clicks
+document.querySelectorAll('.chip').forEach(chip=>{
+  chip.addEventListener('click', ()=>checkProvider(chip,false));
+});
+
+// Auto-refresh: streaming + work apps every 5 minutes
+const autoProviders = ["youtube","netflix","disneyplus","hulu","zoom","slack","m365","teams","github","cloudflare","openai"];
+async function refreshAutoChips(){
+  for(const key of autoProviders){
+    const chip = document.querySelector('.chip[data-provider="'+key+'"]');
+    if(chip) checkProvider(chip,true);
+  }
+  setTimeout(refreshAutoChips, 5*60*1000);
+}
+refreshAutoChips();
+
+/* ----------------- Actions ----------------- */
+btnReboot.onclick = async ()=>{
+  const pin = prompt('Enter the 6-digit Share Code to confirm router restart:', code.textContent || '');
+  if(!pin) return;
+  results.style.display='block'; results.textContent='Restarting router…';
+  try{
+    const r = await fetch('/cgi-bin/supportlink?action=restart_router&pin='+encodeURIComponent(pin), {cache:'no-store'});
+    const j = await r.json();
+    results.textContent = j.ok ? 'Router is rebooting now. This page will become temporarily unavailable.' : 'Restart failed: '+(j.error||'unknown');
+  }catch{ results.textContent='Restart failed.'; }
+};
+
+btnSpeed.onclick = async ()=>{
+  results.style.display='block'; results.textContent='Running speed test… (up to ~1 minute)';
+  try{
+    const r = await fetch('/cgi-bin/supportlink?action=speedtest', {cache:'no-store'});
+    const j = await r.json();
+    if(!j.ok){ results.textContent = 'Speed test error: '+(j.error||'unknown')+(j.install?'\n'+j.install:''); return; }
+    const st = j.speedtest || {};
+    const ping = st.ping?.latency ?? st.ping ?? null;
+    const down_bps = st.download?.bandwidth ? (st.download.bandwidth*8) : (st.download?.bitsPerSecond || null);
+    const up_bps   = st.upload?.bandwidth   ? (st.upload.bandwidth*8)   : (st.upload?.bitsPerSecond   || null);
+    const toMbps = v => v? (v/1e6).toFixed(2) : '—';
+    results.textContent =
+      'Latency: '+(ping!==null ? (ping.toFixed? ping.toFixed(1): ping) : '—')+' ms\n'+
+      'Download: '+toMbps(down_bps)+' Mbps\n'+
+      'Upload:   '+toMbps(up_bps)+' Mbps';
+  }catch{ results.textContent='Speed test failed.'; }
+};
+</script>
+</body>
+</html>
+HTML

--- a/supportlink-wrapper.md
+++ b/supportlink-wrapper.md
@@ -1,0 +1,13 @@
+# SupportLink Wrapper
+
+This script restores the styled SupportLink web UI while keeping all existing JSON API endpoints.
+
+* **HTML mode**: Requests without `action=` or `provider=` and without a JSON `Accept` header render the HTML dashboard.
+* **API mode**: Requests with those parameters or JSON `Accept` are delegated to `supportlink.api`.
+* The deploy script backs up the original API handler to `/www/cgi-bin/supportlink.api` and installs the wrapper at `/www/cgi-bin/supportlink`.
+* Roll back by moving `supportlink.api` back to `supportlink` and restarting `uhttpd`.
+
+## Deploy
+```
+sh scripts/deploy-supportlink-wrapper.sh
+```


### PR DESCRIPTION
## Summary
- add wrapper to serve HTML dashboard or delegate API requests to existing handler
- include deploy script to back up current CGI and install wrapper
- document wrapper behavior and rollback steps

## Testing
- `sh -n scripts/supportlink-wrapper scripts/deploy-supportlink-wrapper.sh`
- `shellcheck` *(fails: command not found, apt repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b656a0f1908324af86f740a1c1c136