### PR TITLE
Add robust JSON parsing for internet details

### DIFF
--- a/README-supportlink.md
+++ b/README-supportlink.md
@@ -2,7 +2,7 @@ SupportLink Static UI
 ====================
 Static `/www/index.html` calls JSON CGI endpoints under `/cgi-bin`.
 
-* `index.html` fetches `/cgi-bin/supportlink`, `/cgi-bin/internet_details`, and `/cgi-bin/outage_check?provider=...`.
+* `index.html` fetches `/cgi-bin/supportlink`, `/cgi-bin/internet-details`, and `/cgi-bin/outage_check?provider=...`.
 * uhttpd home `/www`, `cgi_prefix /cgi-bin`.
 * Cloudflared forwards `${MAC}.nomadconnect.app` to `http://127.0.0.1:80`.
 
@@ -11,5 +11,5 @@ Rollback: `mv /www/index.html.bak /www/index.html && /etc/init.d/uhttpd restart`
 Quick tests:
 `curl http://localhost/`
 `curl http://localhost/cgi-bin/supportlink`
-`curl http://localhost/cgi-bin/internet_details`
+`curl http://localhost/cgi-bin/internet-details`
 `curl http://localhost/cgi-bin/outage_check?provider=att`

--- a/deploy_supportlink_static.sh
+++ b/deploy_supportlink_static.sh
@@ -193,7 +193,7 @@ document.getElementById('btnReboot').onclick = async () => {
 document.getElementById('btnInetDetails').onclick = async () => {
   inetModal.classList.add('open');
   inetBody.innerHTML = '<div class="small muted">Loading network info…</div>';
-  const r = await fetch('/cgi-bin/internet_details');
+  const r = await fetch('/cgi-bin/internet-details');
   const d = await r.json();
   inetBody.innerHTML = '<pre class="mono small">' + JSON.stringify(d, null, 2) + '</pre>';
 };
@@ -233,5 +233,5 @@ fi
 echo "Verify with:"
 echo "  curl -I http://127.0.0.1/"
 echo "  curl http://127.0.0.1/cgi-bin/supportlink"
-echo "  curl http://127.0.0.1/cgi-bin/internet_details"
+echo "  curl http://127.0.0.1/cgi-bin/internet-details"
 echo "  curl http://127.0.0.1/cgi-bin/outage_check?provider=att"

--- a/deploy_supportlink_static.sh
+++ b/deploy_supportlink_static.sh
@@ -73,7 +73,7 @@ cat <<'HTML' > "$INDEX"
 
     <div class="grid" id="stats">
       <div class="stat"><span class="k">Hostname</span><span class="v mono" id="host">—</span></div>
-      <div class="stat"><span class="k">Device ID</span><span class="v mono" id="did">—</span></div>
+      <div class="stat"><span class="k">Tunnel ID</span><span class="v mono" id="did">—</span></div>
       <div class="stat"><span class="k">Share Code (tell support)</span><span class="v mono" id="code">—</span><span class="small muted">Changes every 5 minutes</span></div>
       <div class="stat"><span class="k">Internet</span><span class="v" id="inet">—</span></div>
     </div>
@@ -160,9 +160,9 @@ async function refresh() {
     const r = await fetch('/cgi-bin/supportlink');
     const j = await r.json();
     host.textContent = j.host || j.hostname || '—';
-    did.textContent = j.device_id || j.did || '—';
+    did.textContent = j.tunnel_id || j.device_id || (j.tunnel && j.tunnel.id) || j.did || '—';
     code.textContent = j.code || j.share_code || '—';
-    inet.textContent = j.internet || j.status_text || '—';
+    inet.textContent = j.isp || j.internet || j.status_text || '—';
     const st = j.status || 'warn';
     statusPill.className = 'pill ' + st;
     statusPill.textContent = j.status_text || st;

--- a/package/rvi-probe/files/www/cgi-bin/supportlink
+++ b/package/rvi-probe/files/www/cgi-bin/supportlink
@@ -46,21 +46,24 @@ fi
 
 CODE=$( /usr/bin/rvi-sharecode 2>/dev/null || echo "" )
 
-if ping -c1 -W1 1.1.1.1 >/dev/null 2>&1; then
+ISP=""
+if curl -fs --connect-timeout 5 --max-time 5 https://1.1.1.1 >/dev/null 2>&1; then
     INTERNET="online"
     STATUS="ok"
     STATUS_TEXT="Online"
+    ISP=$(curl -fs --connect-timeout 5 --max-time 5 http://ip-api.com/line?fields=isp 2>/dev/null | head -n1)
 else
     INTERNET="offline"
     STATUS="bad"
     STATUS_TEXT="Offline"
 fi
 
-printf '{"host":"%s","device_id":"%s","code":"%s","internet":"%s","status":"%s","status_text":"%s","tunnel":{"hostname":"%s","id":"%s","state":"%s","code":"%s"}}\n' \
+printf '{"host":"%s","tunnel_id":"%s","code":"%s","internet":"%s","isp":"%s","status":"%s","status_text":"%s","tunnel":{"hostname":"%s","id":"%s","state":"%s","code":"%s"}}\n' \
   "$(json_escape "$HOST")" \
   "$(json_escape "$ID")" \
   "$(json_escape "$CODE")" \
   "$(json_escape "$INTERNET")" \
+  "$(json_escape "$ISP")" \
   "$(json_escape "$STATUS")" \
   "$(json_escape "$STATUS_TEXT")" \
   "$(json_escape "$TUN_HOST")" \

--- a/package/rvi-probe/files/www/cgi-bin/supportlink
+++ b/package/rvi-probe/files/www/cgi-bin/supportlink
@@ -46,16 +46,17 @@ fi
 
 CODE=$( /usr/bin/rvi-sharecode 2>/dev/null || echo "" )
 
+# Query ip-api.com for connectivity and ISP; fall back to offline on failure
+API=$(curl -fs --connect-timeout 5 --max-time 5 "http://ip-api.com/json?fields=status,isp" 2>/dev/null)
 ISP=""
-if curl -fs --connect-timeout 5 --max-time 5 https://1.1.1.1 >/dev/null 2>&1; then
+INTERNET="offline"
+STATUS="bad"
+STATUS_TEXT="Offline"
+if printf '%s' "$API" | grep -q '"status":"success"'; then
     INTERNET="online"
     STATUS="ok"
     STATUS_TEXT="Online"
-    ISP=$(curl -fs --connect-timeout 5 --max-time 5 http://ip-api.com/line?fields=isp 2>/dev/null | head -n1)
-else
-    INTERNET="offline"
-    STATUS="bad"
-    STATUS_TEXT="Offline"
+    ISP=$(printf '%s' "$API" | awk -F'"' '/"isp":/{print $4; exit}')
 fi
 
 printf '{"host":"%s","tunnel_id":"%s","code":"%s","internet":"%s","isp":"%s","status":"%s","status_text":"%s","tunnel":{"hostname":"%s","id":"%s","state":"%s","code":"%s"}}\n' \

--- a/package/rvi-probe/files/www/cgi-bin/supportlink
+++ b/package/rvi-probe/files/www/cgi-bin/supportlink
@@ -1,35 +1,70 @@
 #!/bin/sh
-printf "Content-Type: text/html\r\n\r\n"
-cat <<'HTML'
-<!doctype html><html><head><meta charset="utf-8"><title>RVInternetHelp Support</title>
-<style>body{font-family:system-ui,Segoe UI,Arial;margin:20px}.btn{display:inline-block;padding:10px 14px;margin:8px 8px 8px 0;border:1px solid #ccc;border-radius:10px;text-decoration:none}.badge{padding:2px 8px;border-radius:8px}pre{background:#f6f6f6;padding:10px;border-radius:8px;overflow:auto}.small{font-size:12px;color:#666}</style></head><body>
-<h1>RVInternetHelp — Support Panel</h1>
-<div>
-  <a class="btn" href="/cgi-bin/supportlink?act=share">Generate Share Code</a>
-  <a class="btn" href="/cgi-bin/supportlink?act=speed">Run Speed Test</a>
-  <a class="btn" href="/cgi-bin/supportlink?act=outage">Outage Check</a>
-  <a class="btn" href="/cgi-bin/supportlink?act=diag">Diagnostics</a>
-  <a class="btn" href="/cgi-bin/supportlink?act=cell">Cell Metrics</a>
-</div>
-<div class="small">Worker: $(uci -q get rviprobe.config.worker_url)</div>
-<div id="out"></div>
-HTML
-ACT="${QUERY_STRING#act=}"
-case "$ACT" in
-  share) CODE=$(/usr/bin/rvi-sharecode 2>/dev/null || echo ERR); echo "<h3>Share Code:</h3><pre>$CODE</pre>";;
-  speed) echo "<h3>Speed Test</h3><pre>$(/usr/bin/rvi-speedtest 2>&1)</pre>";;
-  outage) echo "<h3>Outage Check</h3><pre>$(/usr/bin/rvi-outage-check 2>&1)</pre>";;
-  diag) IF=$(uci -q get network.wan.ifname 2>/dev/null); IP=$(ip -4 addr show "$IF" 2>/dev/null | awk '/inet /{print $2}'); echo "<h3>Diagnostics</h3><pre>Host: $(hostname)
-Board: $(cat /tmp/sysinfo/board_name 2>/dev/null)
-Model: $(ubus -S call system board | jq -r .model 2>/dev/null)
-Firmware: $(ubus -S call system board | jq -r .release.description 2>/dev/null)
-WAN IF: $IF
-IP: $IP
-Ping: $(ping -c1 -W1 1.1.1.1 | awk -F'/' '/rtt/{print $5" ms"}')
-</pre>";;
-  cell) echo "<h3>Cell Metrics</h3><pre>$(/usr/lib/rvi-probe/cell.sh 2>&1)</pre>";;
-  *) echo "<p>Use the buttons above to run actions.</p>";;
-esac
-cat <<'HTML'
-</body></html>
-HTML
+# JSON status endpoint for SupportLink dashboard
+printf "Content-Type: application/json\r\n\r\n"
+
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+json_escape() {
+    printf '%s' "$1" | sed \
+        -e 's/\\/\\\\/g' \
+        -e 's/"/\\"/g' \
+        -e 's/\x08/\\b/g' \
+        -e 's/\x0c/\\f/g' \
+        -e 's/\n/\\n/g' \
+        -e 's/\r/\\r/g' \
+        -e 's/\t/\\t/g'
+}
+
+# Find a stable MAC to use as device ID
+pick_mac() {
+    for IF in eth0 eth1 wan wwan0 wwan1 usb0 usb1; do
+        [ -f "/sys/class/net/$IF/address" ] || continue
+        MAC=$(cat "/sys/class/net/$IF/address" 2>/dev/null | tr -d ':\n' | tr 'A-Z' 'a-z')
+        echo "$MAC" | grep -qE '^[0-9a-f]{12}$' && { echo "$MAC"; return 0; }
+    done
+    for IF in $(ls /sys/class/net 2>/dev/null | grep -v '^lo$'); do
+        [ -f "/sys/class/net/$IF/address" ] || continue
+        MAC=$(cat "/sys/class/net/$IF/address" 2>/dev/null | tr -d ':\n' | tr 'A-Z' 'a-z')
+        echo "$MAC" | grep -qE '^[0-9a-f]{12}$' && { echo "$MAC"; return 0; }
+    done
+    return 1
+}
+
+HOST=$(hostname 2>/dev/null)
+ID=$(cat /etc/rvi/cloudflared.tunnel_id 2>/dev/null)
+[ -n "$ID" ] || ID=$(pick_mac 2>/dev/null || echo "")
+
+TUN_HOST=$(cat /etc/rvi/device_host 2>/dev/null)
+[ -n "$TUN_HOST" ] || TUN_HOST="$HOST"
+
+# Determine tunnel state by checking for cloudflared
+if pidof cloudflared >/dev/null 2>&1; then
+    TUN_STATE="up"
+else
+    TUN_STATE="down"
+fi
+
+CODE=$( /usr/bin/rvi-sharecode 2>/dev/null || echo "" )
+
+if ping -c1 -W1 1.1.1.1 >/dev/null 2>&1; then
+    INTERNET="online"
+    STATUS="ok"
+    STATUS_TEXT="Online"
+else
+    INTERNET="offline"
+    STATUS="bad"
+    STATUS_TEXT="Offline"
+fi
+
+printf '{"host":"%s","device_id":"%s","code":"%s","internet":"%s","status":"%s","status_text":"%s","tunnel":{"hostname":"%s","id":"%s","state":"%s","code":"%s"}}\n' \
+  "$(json_escape "$HOST")" \
+  "$(json_escape "$ID")" \
+  "$(json_escape "$CODE")" \
+  "$(json_escape "$INTERNET")" \
+  "$(json_escape "$STATUS")" \
+  "$(json_escape "$STATUS_TEXT")" \
+  "$(json_escape "$TUN_HOST")" \
+  "$(json_escape "$ID")" \
+  "$(json_escape "$TUN_STATE")" \
+  "$(json_escape "$CODE")"
+

--- a/package/rvi-probe/files/www/cgi-bin/supportlink
+++ b/package/rvi-probe/files/www/cgi-bin/supportlink
@@ -46,18 +46,21 @@ fi
 
 CODE=$( /usr/bin/rvi-sharecode 2>/dev/null || echo "" )
 
-# Query ip-api.com for connectivity and ISP; fall back to offline on failure
-API=$(curl -fs --connect-timeout 5 --max-time 5 "http://ip-api.com/json?fields=status,isp" 2>/dev/null)
-ISP=""
-INTERNET="offline"
-STATUS="bad"
-STATUS_TEXT="Offline"
-if printf '%s' "$API" | grep -q '"status":"success"'; then
+# Probe HTTPS connectivity; treat failure as offline
+if curl -fs --connect-timeout 5 https://1.1.1.1 >/dev/null 2>&1; then
     INTERNET="online"
     STATUS="ok"
     STATUS_TEXT="Online"
-    ISP=$(printf '%s' "$API" | awk -F'"' '/"isp":/{print $4; exit}')
+else
+    INTERNET="offline"
+    STATUS="bad"
+    STATUS_TEXT="Offline"
 fi
+
+# Query ip-api.com only to populate ISP
+API=$(curl -fs --connect-timeout 5 --max-time 5 "http://ip-api.com/json?fields=isp" 2>/dev/null)
+ISP=$(printf '%s' "$API" |
+    awk -F'"' '{for(i=1;i<NF;i++) if($i=="isp"){print $(i+2);break}}')
 
 printf '{"host":"%s","tunnel_id":"%s","code":"%s","internet":"%s","isp":"%s","status":"%s","status_text":"%s","tunnel":{"hostname":"%s","id":"%s","state":"%s","code":"%s"}}\n' \
   "$(json_escape "$HOST")" \

--- a/package/rvi-probe/files/www/index.html
+++ b/package/rvi-probe/files/www/index.html
@@ -29,11 +29,13 @@
   .accent{border-color:#1e40af}
   .danger{border-color:#7f1d1d}
   .wide{width:100%}
-  .mono{font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono","Courier New", monospace}
+  .mono{font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono","Courier New", monospace;overflow-wrap:anywhere}
   .small{font-size:12px}
   .hr{height:1px;background:#1f2937;margin:16px 0}
   .log{background:#0b1022;border:1px solid #1f2937;border-radius:12px;padding:12px;white-space:pre-wrap;max-height:300px;overflow:auto}
   .row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+
+  .span2{grid-column:span 2}
 
   /* Modal + chips */
   .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:16px;z-index:1000;background:rgba(0,0,0,.45)}
@@ -63,8 +65,8 @@
     <p class="sub">Fast help from RV Internet Help. Keep this page open if you’re on the phone with support.</p>
 
     <div class="grid" id="stats">
-      <div class="stat"><span class="k">Hostname</span><span class="v mono" id="host">—</span></div>
-      <div class="stat"><span class="k">Tunnel ID</span><span class="v mono" id="did">—</span></div>
+      <div class="stat span2"><span class="k">Hostname</span><span class="v mono" id="host">—</span></div>
+      <div class="stat span2"><span class="k">Tunnel ID</span><span class="v mono" id="did">—</span></div>
       <div class="stat"><span class="k">Share Code (tell support)</span><span class="v mono" id="code">—</span><span class="small muted">Changes every 5 minutes</span></div>
       <div class="stat"><span class="k">Internet</span><span class="v" id="inet">—</span></div>
     </div>

--- a/package/rvi-probe/files/www/index.html
+++ b/package/rvi-probe/files/www/index.html
@@ -64,7 +64,7 @@
 
     <div class="grid" id="stats">
       <div class="stat"><span class="k">Hostname</span><span class="v mono" id="host">—</span></div>
-      <div class="stat"><span class="k">Device ID</span><span class="v mono" id="did">—</span></div>
+      <div class="stat"><span class="k">Tunnel ID</span><span class="v mono" id="did">—</span></div>
       <div class="stat"><span class="k">Share Code (tell support)</span><span class="v mono" id="code">—</span><span class="small muted">Changes every 5 minutes</span></div>
       <div class="stat"><span class="k">Internet</span><span class="v" id="inet">—</span></div>
     </div>
@@ -192,10 +192,10 @@ async function getStatus(){
   try{
     const r = await fetch('/cgi-bin/supportlink', {cache:'no-store'});
     const j = await r.json();
-    currentHost = (j && j.tunnel && j.tunnel.hostname) || '';
+    currentHost = j.host || (j.tunnel && j.tunnel.hostname) || '';
     host.textContent = currentHost || '—';
-    did.textContent  = (j && j.tunnel && j.tunnel.id) || '—';
-    inet.textContent = (j && j.internet || '—').toUpperCase();
+    did.textContent  = j.tunnel_id || j.device_id || (j.tunnel && j.tunnel.id) || '—';
+    inet.textContent = j.isp || j.internet || j.status_text || '—';
     setPill((j && j.tunnel && j.tunnel.state) || 'down');
     await ensureCode(j && j.tunnel && j.tunnel.code);
     lastFetch = Date.now();

--- a/package/rvi-probe/files/www/index.html
+++ b/package/rvi-probe/files/www/index.html
@@ -216,7 +216,7 @@ btnInetDetails.onclick = async ()=>{
   inetBody.innerHTML = '<div class="small muted">Loading network info…</div>';
   outageResults.innerHTML = '';
   try{
-    const r = await fetch('/cgi-bin/internet_details', {cache:'no-store'});
+    const r = await fetch('/cgi-bin/internet-details', {cache:'no-store'});
     const txt = await r.text();
     let j; try{ j = JSON.parse(txt); }catch{ throw new Error('Bad JSON from CGI: '+txt.slice(0,120)); }
     if (j.status === 'error') throw new Error(j.message || 'lookup failed');

--- a/package/rvi-probe/root/www/cgi-bin/internet-details
+++ b/package/rvi-probe/root/www/cgi-bin/internet-details
@@ -1,0 +1,38 @@
+#!/bin/sh
+printf "Content-Type: application/json\r\n\r\n"
+
+json_escape() {
+    printf '%s' "$1" | sed \
+        -e 's/\\/\\\\/g' \
+        -e 's/"/\\"/g' \
+        -e 's/\x08/\\b/g' \
+        -e 's/\x0c/\\f/g' \
+        -e 's/\n/\\n/g' \
+        -e 's/\r/\\r/g' \
+        -e 's/\t/\\t/g'
+}
+
+WORKER_URL="$(uci -q get rviprobe.config.worker_url 2>/dev/null)"
+DATA=""
+if [ -n "$WORKER_URL" ]; then
+    DATA="$(curl -fsL "$WORKER_URL/internet-details" 2>/dev/null)"
+fi
+if [ -z "$DATA" ]; then
+    DATA="$(curl -fsL 'http://ip-api.com/json/?fields=isp,asn,asname,country,regionName,city' 2>/dev/null)"
+fi
+
+ISP="$(printf '%s' "$DATA" | awk -F'"isp":"' '{print $2}' | awk -F'"' '{print $1}')"
+ASN="$(printf '%s' "$DATA" | awk -F'"asn":' '{print $2}' | awk -F'[,}]' '{print $1}')"
+ASNAME="$(printf '%s' "$DATA" | awk -F'"asname":"' '{print $2}' | awk -F'"' '{print $1}')"
+COUNTRY="$(printf '%s' "$DATA" | awk -F'"country":"' '{print $2}' | awk -F'"' '{print $1}')"
+REGION="$(printf '%s' "$DATA" | awk -F'"regionName":"' '{print $2}' | awk -F'"' '{print $1}')"
+CITY="$(printf '%s' "$DATA" | awk -F'"city":"' '{print $2}' | awk -F'"' '{print $1}')"
+
+printf '{"isp":"%s","asn":"%s","asname":"%s","country":"%s","region":"%s","city":"%s"}\n' \
+    "$(json_escape "$ISP")" \
+    "$(json_escape "$ASN")" \
+    "$(json_escape "$ASNAME")" \
+    "$(json_escape "$COUNTRY")" \
+    "$(json_escape "$REGION")" \
+    "$(json_escape "$CITY")"
+

--- a/package/rvi-probe/root/www/cgi-bin/supportlink
+++ b/package/rvi-probe/root/www/cgi-bin/supportlink
@@ -46,21 +46,24 @@ fi
 
 CODE=$( /usr/bin/rvi-sharecode 2>/dev/null || echo "" )
 
-if ping -c1 -W1 1.1.1.1 >/dev/null 2>&1; then
+ISP=""
+if curl -fs --connect-timeout 5 --max-time 5 https://1.1.1.1 >/dev/null 2>&1; then
     INTERNET="online"
     STATUS="ok"
     STATUS_TEXT="Online"
+    ISP=$(curl -fs --connect-timeout 5 --max-time 5 http://ip-api.com/line?fields=isp 2>/dev/null | head -n1)
 else
     INTERNET="offline"
     STATUS="bad"
     STATUS_TEXT="Offline"
 fi
 
-printf '{"host":"%s","device_id":"%s","code":"%s","internet":"%s","status":"%s","status_text":"%s","tunnel":{"hostname":"%s","id":"%s","state":"%s","code":"%s"}}\n' \
+printf '{"host":"%s","tunnel_id":"%s","code":"%s","internet":"%s","isp":"%s","status":"%s","status_text":"%s","tunnel":{"hostname":"%s","id":"%s","state":"%s","code":"%s"}}\n' \
   "$(json_escape "$HOST")" \
   "$(json_escape "$ID")" \
   "$(json_escape "$CODE")" \
   "$(json_escape "$INTERNET")" \
+  "$(json_escape "$ISP")" \
   "$(json_escape "$STATUS")" \
   "$(json_escape "$STATUS_TEXT")" \
   "$(json_escape "$TUN_HOST")" \

--- a/package/rvi-probe/root/www/cgi-bin/supportlink
+++ b/package/rvi-probe/root/www/cgi-bin/supportlink
@@ -46,16 +46,17 @@ fi
 
 CODE=$( /usr/bin/rvi-sharecode 2>/dev/null || echo "" )
 
+# Query ip-api.com for connectivity and ISP; fall back to offline on failure
+API=$(curl -fs --connect-timeout 5 --max-time 5 "http://ip-api.com/json?fields=status,isp" 2>/dev/null)
 ISP=""
-if curl -fs --connect-timeout 5 --max-time 5 https://1.1.1.1 >/dev/null 2>&1; then
+INTERNET="offline"
+STATUS="bad"
+STATUS_TEXT="Offline"
+if printf '%s' "$API" | grep -q '"status":"success"'; then
     INTERNET="online"
     STATUS="ok"
     STATUS_TEXT="Online"
-    ISP=$(curl -fs --connect-timeout 5 --max-time 5 http://ip-api.com/line?fields=isp 2>/dev/null | head -n1)
-else
-    INTERNET="offline"
-    STATUS="bad"
-    STATUS_TEXT="Offline"
+    ISP=$(printf '%s' "$API" | awk -F'"' '/"isp":/{print $4; exit}')
 fi
 
 printf '{"host":"%s","tunnel_id":"%s","code":"%s","internet":"%s","isp":"%s","status":"%s","status_text":"%s","tunnel":{"hostname":"%s","id":"%s","state":"%s","code":"%s"}}\n' \

--- a/package/rvi-probe/root/www/cgi-bin/supportlink
+++ b/package/rvi-probe/root/www/cgi-bin/supportlink
@@ -1,35 +1,70 @@
 #!/bin/sh
-printf "Content-Type: text/html\r\n\r\n"
-cat <<'HTML'
-<!doctype html><html><head><meta charset="utf-8"><title>RVInternetHelp Support</title>
-<style>body{font-family:system-ui,Segoe UI,Arial;margin:20px}.btn{display:inline-block;padding:10px 14px;margin:8px 8px 8px 0;border:1px solid #ccc;border-radius:10px;text-decoration:none}.badge{padding:2px 8px;border-radius:8px}pre{background:#f6f6f6;padding:10px;border-radius:8px;overflow:auto}.small{font-size:12px;color:#666}</style></head><body>
-<h1>RVInternetHelp — Support Panel</h1>
-<div>
-  <a class="btn" href="/cgi-bin/supportlink?act=share">Generate Share Code</a>
-  <a class="btn" href="/cgi-bin/supportlink?act=speed">Run Speed Test</a>
-  <a class="btn" href="/cgi-bin/supportlink?act=outage">Outage Check</a>
-  <a class="btn" href="/cgi-bin/supportlink?act=diag">Diagnostics</a>
-  <a class="btn" href="/cgi-bin/supportlink?act=cell">Cell Metrics</a>
-</div>
-<div class="small">Worker: $(uci -q get rviprobe.config.worker_url)</div>
-<div id="out"></div>
-HTML
-ACT="${QUERY_STRING#act=}"
-case "$ACT" in
-  share) CODE=$(/usr/bin/rvi-sharecode 2>/dev/null || echo ERR); echo "<h3>Share Code:</h3><pre>$CODE</pre>";;
-  speed) echo "<h3>Speed Test</h3><pre>$(/usr/bin/rvi-speedtest 2>&1)</pre>";;
-  outage) echo "<h3>Outage Check</h3><pre>$(/usr/bin/rvi-outage-check 2>&1)</pre>";;
-  diag) IF=$(uci -q get network.wan.ifname 2>/dev/null); IP=$(ip -4 addr show "$IF" 2>/dev/null | awk '/inet /{print $2}'); echo "<h3>Diagnostics</h3><pre>Host: $(hostname)
-Board: $(cat /tmp/sysinfo/board_name 2>/dev/null)
-Model: $(ubus -S call system board | jq -r .model 2>/dev/null)
-Firmware: $(ubus -S call system board | jq -r .release.description 2>/dev/null)
-WAN IF: $IF
-IP: $IP
-Ping: $(ping -c1 -W1 1.1.1.1 | awk -F'/' '/rtt/{print $5" ms"}')
-</pre>";;
-  cell) echo "<h3>Cell Metrics</h3><pre>$(/usr/lib/rvi-probe/cell.sh 2>&1)</pre>";;
-  *) echo "<p>Use the buttons above to run actions.</p>";;
-esac
-cat <<'HTML'
-</body></html>
-HTML
+# JSON status endpoint for SupportLink dashboard
+printf "Content-Type: application/json\r\n\r\n"
+
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+
+json_escape() {
+    printf '%s' "$1" | sed \
+        -e 's/\\/\\\\/g' \
+        -e 's/"/\\"/g' \
+        -e 's/\x08/\\b/g' \
+        -e 's/\x0c/\\f/g' \
+        -e 's/\n/\\n/g' \
+        -e 's/\r/\\r/g' \
+        -e 's/\t/\\t/g'
+}
+
+# Find a stable MAC to use as device ID
+pick_mac() {
+    for IF in eth0 eth1 wan wwan0 wwan1 usb0 usb1; do
+        [ -f "/sys/class/net/$IF/address" ] || continue
+        MAC=$(cat "/sys/class/net/$IF/address" 2>/dev/null | tr -d ':\n' | tr 'A-Z' 'a-z')
+        echo "$MAC" | grep -qE '^[0-9a-f]{12}$' && { echo "$MAC"; return 0; }
+    done
+    for IF in $(ls /sys/class/net 2>/dev/null | grep -v '^lo$'); do
+        [ -f "/sys/class/net/$IF/address" ] || continue
+        MAC=$(cat "/sys/class/net/$IF/address" 2>/dev/null | tr -d ':\n' | tr 'A-Z' 'a-z')
+        echo "$MAC" | grep -qE '^[0-9a-f]{12}$' && { echo "$MAC"; return 0; }
+    done
+    return 1
+}
+
+HOST=$(hostname 2>/dev/null)
+ID=$(cat /etc/rvi/cloudflared.tunnel_id 2>/dev/null)
+[ -n "$ID" ] || ID=$(pick_mac 2>/dev/null || echo "")
+
+TUN_HOST=$(cat /etc/rvi/device_host 2>/dev/null)
+[ -n "$TUN_HOST" ] || TUN_HOST="$HOST"
+
+# Determine tunnel state by checking for cloudflared
+if pidof cloudflared >/dev/null 2>&1; then
+    TUN_STATE="up"
+else
+    TUN_STATE="down"
+fi
+
+CODE=$( /usr/bin/rvi-sharecode 2>/dev/null || echo "" )
+
+if ping -c1 -W1 1.1.1.1 >/dev/null 2>&1; then
+    INTERNET="online"
+    STATUS="ok"
+    STATUS_TEXT="Online"
+else
+    INTERNET="offline"
+    STATUS="bad"
+    STATUS_TEXT="Offline"
+fi
+
+printf '{"host":"%s","device_id":"%s","code":"%s","internet":"%s","status":"%s","status_text":"%s","tunnel":{"hostname":"%s","id":"%s","state":"%s","code":"%s"}}\n' \
+  "$(json_escape "$HOST")" \
+  "$(json_escape "$ID")" \
+  "$(json_escape "$CODE")" \
+  "$(json_escape "$INTERNET")" \
+  "$(json_escape "$STATUS")" \
+  "$(json_escape "$STATUS_TEXT")" \
+  "$(json_escape "$TUN_HOST")" \
+  "$(json_escape "$ID")" \
+  "$(json_escape "$TUN_STATE")" \
+  "$(json_escape "$CODE")"
+

--- a/package/rvi-probe/root/www/cgi-bin/supportlink
+++ b/package/rvi-probe/root/www/cgi-bin/supportlink
@@ -46,18 +46,21 @@ fi
 
 CODE=$( /usr/bin/rvi-sharecode 2>/dev/null || echo "" )
 
-# Query ip-api.com for connectivity and ISP; fall back to offline on failure
-API=$(curl -fs --connect-timeout 5 --max-time 5 "http://ip-api.com/json?fields=status,isp" 2>/dev/null)
-ISP=""
-INTERNET="offline"
-STATUS="bad"
-STATUS_TEXT="Offline"
-if printf '%s' "$API" | grep -q '"status":"success"'; then
+# Probe HTTPS connectivity; treat failure as offline
+if curl -fs --connect-timeout 5 https://1.1.1.1 >/dev/null 2>&1; then
     INTERNET="online"
     STATUS="ok"
     STATUS_TEXT="Online"
-    ISP=$(printf '%s' "$API" | awk -F'"' '/"isp":/{print $4; exit}')
+else
+    INTERNET="offline"
+    STATUS="bad"
+    STATUS_TEXT="Offline"
 fi
+
+# Query ip-api.com only to populate ISP
+API=$(curl -fs --connect-timeout 5 --max-time 5 "http://ip-api.com/json?fields=isp" 2>/dev/null)
+ISP=$(printf '%s' "$API" |
+    awk -F'"' '{for(i=1;i<NF;i++) if($i=="isp"){print $(i+2);break}}')
 
 printf '{"host":"%s","tunnel_id":"%s","code":"%s","internet":"%s","isp":"%s","status":"%s","status_text":"%s","tunnel":{"hostname":"%s","id":"%s","state":"%s","code":"%s"}}\n' \
   "$(json_escape "$HOST")" \

--- a/package/rvi-probe/root/www/index.html
+++ b/package/rvi-probe/root/www/index.html
@@ -29,11 +29,13 @@
   .accent{border-color:#1e40af}
   .danger{border-color:#7f1d1d}
   .wide{width:100%}
-  .mono{font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono","Courier New", monospace}
+  .mono{font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono","Courier New", monospace;overflow-wrap:anywhere}
   .small{font-size:12px}
   .hr{height:1px;background:#1f2937;margin:16px 0}
   .log{background:#0b1022;border:1px solid #1f2937;border-radius:12px;padding:12px;white-space:pre-wrap;max-height:300px;overflow:auto}
   .row{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+
+  .span2{grid-column:span 2}
 
   /* Modal + chips */
   .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:16px;z-index:1000;background:rgba(0,0,0,.45)}
@@ -63,8 +65,8 @@
     <p class="sub">Fast help from RV Internet Help. Keep this page open if you’re on the phone with support.</p>
 
     <div class="grid" id="stats">
-      <div class="stat"><span class="k">Hostname</span><span class="v mono" id="host">—</span></div>
-      <div class="stat"><span class="k">Tunnel ID</span><span class="v mono" id="did">—</span></div>
+      <div class="stat span2"><span class="k">Hostname</span><span class="v mono" id="host">—</span></div>
+      <div class="stat span2"><span class="k">Tunnel ID</span><span class="v mono" id="did">—</span></div>
       <div class="stat"><span class="k">Share Code (tell support)</span><span class="v mono" id="code">—</span><span class="small muted">Changes every 5 minutes</span></div>
       <div class="stat"><span class="k">Internet</span><span class="v" id="inet">—</span></div>
     </div>

--- a/package/rvi-probe/root/www/index.html
+++ b/package/rvi-probe/root/www/index.html
@@ -184,7 +184,7 @@ document.getElementById('btnReboot').onclick = async () => {
 document.getElementById('btnInetDetails').onclick = async () => {
   inetModal.classList.add('open');
   inetBody.innerHTML = '<div class="small muted">Loading network info…</div>';
-  const r = await fetch('/cgi-bin/internet_details');
+  const r = await fetch('/cgi-bin/internet-details');
   const d = await r.json();
   inetBody.innerHTML = '<pre class="mono small">' + JSON.stringify(d, null, 2) + '</pre>';
 };

--- a/package/rvi-probe/root/www/index.html
+++ b/package/rvi-probe/root/www/index.html
@@ -64,7 +64,7 @@
 
     <div class="grid" id="stats">
       <div class="stat"><span class="k">Hostname</span><span class="v mono" id="host">—</span></div>
-      <div class="stat"><span class="k">Device ID</span><span class="v mono" id="did">—</span></div>
+      <div class="stat"><span class="k">Tunnel ID</span><span class="v mono" id="did">—</span></div>
       <div class="stat"><span class="k">Share Code (tell support)</span><span class="v mono" id="code">—</span><span class="small muted">Changes every 5 minutes</span></div>
       <div class="stat"><span class="k">Internet</span><span class="v" id="inet">—</span></div>
     </div>
@@ -151,9 +151,9 @@ async function refresh() {
     const r = await fetch('/cgi-bin/supportlink');
     const j = await r.json();
     host.textContent = j.host || j.hostname || '—';
-    did.textContent = j.device_id || j.did || '—';
+    did.textContent = j.tunnel_id || j.device_id || (j.tunnel && j.tunnel.id) || j.did || '—';
     code.textContent = j.code || j.share_code || '—';
-    inet.textContent = j.internet || j.status_text || '—';
+    inet.textContent = j.isp || j.internet || j.status_text || '—';
     const st = j.status || 'warn';
     statusPill.className = 'pill ' + st;
     statusPill.textContent = j.status_text || st;


### PR DESCRIPTION
## Summary
- add internet-details CGI script with json_escape helper
- parse ip-api data using awk to populate ISP, ASN, AS name, country, region, and city

## Testing
- `sh package/rvi-probe/root/www/cgi-bin/internet-details` *(ip-api request returned 403; JSON fields empty)*

------
https://chatgpt.com/codex/tasks/task_e_68b6fd39ffd48324bebb16ebe1eba225