### PR TITLE
Add LuCI access button with share code confirmation

### DIFF
--- a/deploy_supportlink_static.sh
+++ b/deploy_supportlink_static.sh
@@ -88,6 +88,7 @@ cat <<'HTML' > "$INDEX"
     <div class="actions">
       <button class="accent" id="btnSpeed">Run Speed Test</button>
       <button id="btnInetDetails">Internet Details</button>
+      <button id="btnLuci">Router Settings</button>
       <button class="danger" id="btnReboot">Restart My Router</button>
     </div>
 
@@ -181,6 +182,13 @@ document.getElementById('btnSpeed').onclick = async () => {
   results.textContent = 'Running speed test...';
   const r = await fetch('/cgi-bin/supportlink?action=speed');
   results.textContent = await r.text();
+};
+
+document.getElementById('btnLuci').onclick = () => {
+  const pin = prompt('Enter the 6-digit Share Code to open router settings:', code.textContent || '');
+  if(!pin) return;
+  if(pin.trim() !== (code.textContent || '').trim()) { alert('Incorrect Share Code'); return; }
+  location.href = '/cgi-bin/luci';
 };
 
 document.getElementById('btnReboot').onclick = async () => {

--- a/package/rvi-probe/files/www/index.html
+++ b/package/rvi-probe/files/www/index.html
@@ -81,6 +81,7 @@
     <div class="actions">
       <button class="accent" id="btnSpeed">Run Speed Test</button>
       <button id="btnInetDetails">Internet Details</button>
+      <button id="btnLuci">Router Settings</button>
       <button class="danger" id="btnReboot">Restart My Router</button>
     </div>
 
@@ -144,8 +145,9 @@ const pill = $('#statusPill'),
       ago  = $('#ago'),
       results = $('#results'),
       btnSpeed = $('#btnSpeed'),
-      btnReboot = $('#btnReboot'),
       btnInetDetails = $('#btnInetDetails'),
+      btnLuci = $('#btnLuci'),
+      btnReboot = $('#btnReboot'),
       inetModal = $('#inetModal'),
       inetClose = $('#inetClose'),
       inetBody = $('#inetBody'),
@@ -289,6 +291,13 @@ async function refreshAutoChips(){
 refreshAutoChips();
 
 /* ----------------- Actions ----------------- */
+btnLuci.onclick = ()=>{
+  const pin = prompt('Enter the 6-digit Share Code to open router settings:', code.textContent || '');
+  if(!pin) return;
+  if(pin.trim() !== (code.textContent || '').trim()){ alert('Incorrect Share Code.'); return; }
+  location.href = '/cgi-bin/luci';
+};
+
 btnReboot.onclick = async ()=>{
   const pin = prompt('Enter the 6-digit Share Code to confirm router restart:', code.textContent || '');
   if(!pin) return;

--- a/package/rvi-probe/root/www/index.html
+++ b/package/rvi-probe/root/www/index.html
@@ -81,6 +81,7 @@
     <div class="actions">
       <button class="accent" id="btnSpeed">Run Speed Test</button>
       <button id="btnInetDetails">Internet Details</button>
+      <button id="btnLuci">Router Settings</button>
       <button class="danger" id="btnReboot">Restart My Router</button>
     </div>
 
@@ -148,6 +149,7 @@ const inetClose = document.getElementById('inetClose');
 const inetBody = document.getElementById('inetBody');
 const outageResults = document.getElementById('outageResults');
 const btnInetDetails = document.getElementById('btnInetDetails');
+const btnLuci = document.getElementById('btnLuci');
 
 async function refresh() {
   try {
@@ -175,6 +177,13 @@ document.getElementById('btnSpeed').onclick = async () => {
   results.textContent = 'Running speed test...';
   const r = await fetch('/cgi-bin/supportlink?action=speed');
   results.textContent = await r.text();
+};
+
+btnLuci.onclick = () => {
+  const pin = prompt('Enter the 6-digit Share Code to open router settings:', code.textContent || '');
+  if(!pin) return;
+  if(pin.trim() !== (code.textContent || '').trim()) { alert('Incorrect Share Code'); return; }
+  location.href = '/cgi-bin/luci';
 };
 
 document.getElementById('btnReboot').onclick = async () => {


### PR DESCRIPTION
## Summary
- Add Router Settings button to SupportLink interfaces to open `/cgi-bin/luci`
- Require share code confirmation before redirecting to LuCI
- Update static deploy script to include new button and validation

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d5dab6d48324a71f17d4c7ede5c8